### PR TITLE
Set 'Hangout' index to accept requests w/o auth

### DIFF
--- a/app/routes/hangout_routes.js
+++ b/app/routes/hangout_routes.js
@@ -29,7 +29,7 @@ const router = express.Router()
 
 // INDEX
 // GET /hangouts
-router.get('/hangouts', requireToken, (req, res, next) => {
+router.get('/hangouts', (req, res, next) => {
   Hangout.find()
     .then(hangouts => {
       // `hangouts` will be an array of Mongoose documents


### PR DESCRIPTION
The index request for the Hangout resource now accepts requests w/o
authorization. This allows for users that are logged out to see
current events.